### PR TITLE
Update installation instructions, add missing dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+bacillus.10k.mgf
+XuanjiNovo_100M_massnet.ckpt
+**/__pycache__

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ pip install -r ./requirements.txt
 installing gcc and g++:
 
 ```bash
-conda install -c conda-forge gcc
-conda install -c conda-forge cxx-compiler
+conda install -c conda-forge gcc cxx-compiler ninja
 ```
 
 then install ctcdecode, which is the package for ctc-beamsearch decoding

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ bravado==11.0.3
 bravado-core==5.17.1
 brotlipy==0.7.0
 cachetools==4.2.2
+captum==0.8.0
 casanovo==3.2.0
 certifi==2022.12.7
 cffi==1.15.1


### PR DESCRIPTION
Adds the missing dependency `captum` to the `requirements.txt` and updates the `README` to install `Ninja` in the conda encironment. Also adds a `.gitignore` file.

Fixes #1 